### PR TITLE
Updated JBOSS_HOME and fixed redirection to /dev/null

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM jboss/wildfly
 
-ADD customization /opt/wildfly/customization/
-ADD modules /opt/wildfly/modules/
+ADD customization /opt/jboss/wildfly/customization/
+ADD modules /opt/jboss/wildfly/modules/
 
-RUN /opt/wildfly/customization/execute.sh
+RUN /opt/jboss/wildfly/customization/execute.sh
 

--- a/cli/customization/execute.sh
+++ b/cli/customization/execute.sh
@@ -5,7 +5,7 @@
 # The default mode is 'standalone' and default configuration is based on the
 # mode. It can be 'standalone.xml' or 'domain.xml'.
 
-JBOSS_HOME=/opt/wildfly
+JBOSS_HOME=/opt/jboss/wildfly
 JBOSS_CLI=$JBOSS_HOME/bin/jboss-cli.sh
 JBOSS_MODE=${1:-"standalone"}
 JBOSS_CONFIG=${2:-"$JBOSS_MODE.xml"}
@@ -17,7 +17,7 @@ function wait_for_server() {
 }
 
 echo "=> Starting WildFly server"
-$JBOSS_HOME/bin/$JBOSS_MODE.sh -c $JBOSS_CONFIG >dev/null &
+$JBOSS_HOME/bin/$JBOSS_MODE.sh -c $JBOSS_CONFIG >/dev/null &
 
 echo "=> Waiting for the server to boot"
 wait_for_server


### PR DESCRIPTION
This fixes https://github.com/goldmann/wildfly-docker-configuration/issues/1
