### PR TITLE
Updating augeas example to jboss/wildfly:latest (9.0.1).

### DIFF
--- a/augeas/Dockerfile
+++ b/augeas/Dockerfile
@@ -1,6 +1,6 @@
 FROM jboss/wildfly
 
 #Add the file with Augeas commands
-ADD augeas.cmd /opt/wildfly/
+ADD augeas.cmd /opt/jboss/wildfly/
 # Run augeas
-RUN augtool -LA -e -f /opt/wildfly/augeas.cmd
+RUN augtool -LA -e -f /opt/jboss/wildfly/augeas.cmd

--- a/augeas/augeas.cmd
+++ b/augeas/augeas.cmd
@@ -1,5 +1,5 @@
 set /augeas/load/Xml/lens Xml.lns
-set /augeas/load/Xml/incl[2] /opt/wildfly/standalone/configuration/standalone.xml
+set /augeas/load/Xml/incl[2] /opt/jboss/wildfly/standalone/configuration/standalone.xml
 load
 defvar subsystem "/files/opt/wildfly/standalone/configuration/standalone.xml/server/profile/subsystem[#attribute/xmlns='urn:jboss:domain:logging:3.0']"
 set $subsystem/console-handler/level/#attribute/name "DEBUG"

--- a/augeas/augeas.cmd
+++ b/augeas/augeas.cmd
@@ -1,7 +1,7 @@
 set /augeas/load/Xml/lens Xml.lns
 set /augeas/load/Xml/incl[2] /opt/wildfly/standalone/configuration/standalone.xml
 load
-defvar subsystem "/files/opt/wildfly/standalone/configuration/standalone.xml/server/profile/subsystem[#attribute/xmlns='urn:jboss:domain:logging:2.0']"
+defvar subsystem "/files/opt/wildfly/standalone/configuration/standalone.xml/server/profile/subsystem[#attribute/xmlns='urn:jboss:domain:logging:3.0']"
 set $subsystem/console-handler/level/#attribute/name "DEBUG"
 set $subsystem/root-logger/level/#attribute/name "DEBUG"
 set $subsystem/logger[last()+1]/#attribute/category "pl.goldmann.example"


### PR DESCRIPTION
Hi, Marek.

I noticed the Docker augeas example is not up-to-date with jboss/wildfly:latest's filesystem and standalone.xml contents.

Please check this pull request.

Thanks!
